### PR TITLE
Add Redis-backed reminder scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,45 @@
 # fastapi-webhook-receiver
-fastapi-webhook-receiver
 
-Test
+FastAPI service that accepts reminders, stores them in a database, and uses a Redis sorted-set queue to fire IFTTT webhooks at the scheduled time. Redis handles the hot queue so the database is not polled every minute.
+
+## Prerequisites
+- Python 3.10+
+- Redis running locally (or provide `REDIS_URL`)
+- PostgreSQL if you want production storage (defaults to SQLite for local dev)
+
+## Configuration
+Environment variables (defaults shown):
+- `DATABASE_URL`: `sqlite+aiosqlite:///./reminders.db`
+- `REDIS_URL`: `redis://localhost:6379/0`
+- `REDIS_QUEUE_KEY`: `ifttt_reminders_queue`
+- `DISPATCH_INTERVAL`: `60` (seconds between queue checks)
+- `IFTTT_EVENT`: IFTTT event name (required to actually send)
+- `IFTTT_KEY`: IFTTT webhook key (required to actually send)
+
+## Install & Run
+```bash
+python -m venv .venv && .venv/Scripts/activate
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+## API
+- `POST /reminders` – Schedule a reminder.
+	```json
+	{
+		"when": "2026-01-07T10:00:00Z",
+		"message1": "Value 1",
+		"message2": "Value 2",
+		"message3": "Value 3"
+	}
+	```
+	Response: `{ "status": "scheduled", "execution_time": "...", "id": 1 }`
+
+- `GET /health` – Basic health check.
+
+## How it works
+1) The reminder is written to the database (system of record).
+2) The reminder payload is added to a Redis ZSET with the execution timestamp as the score.
+3) A background scheduler wakes every `DISPATCH_INTERVAL` seconds, reads due entries from Redis only, dispatches to IFTTT, and removes them from the queue.
 
 [![Docker Repository on Quay](https://quay.io/repository/hemanth22/fastapi-webhook-receiver/status "Docker Repository on Quay")](https://quay.io/repository/hemanth22/fastapi-webhook-receiver)

--- a/main.py
+++ b/main.py
@@ -1,23 +1,158 @@
+import json
+import logging
+import os
+import time
+from contextlib import asynccontextmanager
+from datetime import datetime
+from typing import Optional
+
+import httpx
+import redis.asyncio as redis
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from fastapi import FastAPI, HTTPException
-from fastapi import Request
+from pydantic import BaseModel, Field
+from sqlalchemy import Column, DateTime, Integer, String
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import declarative_base
 
-app = FastAPI()
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite+aiosqlite:///./reminders.db")
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+REDIS_QUEUE_KEY = os.getenv("REDIS_QUEUE_KEY", "ifttt_reminders_queue")
+DISPATCH_INTERVAL = int(os.getenv("DISPATCH_INTERVAL", "60"))
 
-@app.post("/webhook")
-async def webhook(request: Request):
-    content_type = request.headers.get("Content-Type")
+IFTTT_EVENT = os.getenv("IFTTT_EVENT")
+IFTTT_KEY = os.getenv("IFTTT_KEY")
+IFTTT_URL_TEMPLATE = "https://maker.ifttt.com/trigger/{event}/with/key/{key}"
 
-    if content_type == "application/json":
-        # Handle JSON payload
-        payload = await request.json()
-        print("Webhook received (JSON):", payload)
-        # Handle the JSON payload as needed
-    elif content_type == "application/x-www-form-urlencoded":
-        # Handle form data
-        form_data = await request.form()
-        print("Webhook received (Form data):", form_data)
-        # Handle the form data as needed
-    else:
-        raise HTTPException(status_code=400, detail="Unsupported content type")
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
-    return {"status": "Webhook received successfully"}
+engine = create_async_engine(DATABASE_URL, echo=False, future=True)
+AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+Base = declarative_base()
+
+redis_client: Optional[redis.Redis] = None
+scheduler: Optional[AsyncIOScheduler] = None
+
+
+class Reminder(Base):
+    __tablename__ = "ifttt_remainder"
+
+    id = Column(Integer, primary_key=True)
+    datetime_col = Column("datetime", DateTime, nullable=False)
+    message1 = Column(String, nullable=False)
+    message2 = Column(String, nullable=True)
+    message3 = Column(String, nullable=True)
+
+
+class ReminderCreate(BaseModel):
+    when: datetime = Field(..., description="Execution time in ISO 8601 format")
+    message1: str = Field(..., description="Primary value for the IFTTT webhook")
+    message2: Optional[str] = Field(None, description="Secondary value for the IFTTT webhook")
+    message3: Optional[str] = Field(None, description="Tertiary value for the IFTTT webhook")
+
+
+async def trigger_ifttt(payload: dict) -> None:
+    if not IFTTT_EVENT or not IFTTT_KEY:
+        logger.warning("IFTTT_EVENT and IFTTT_KEY must be set to dispatch webhooks. Skipping send.")
+        return
+
+    ifttt_payload = {
+        "value1": payload.get("message1"),
+        "value2": payload.get("message2"),
+        "value3": payload.get("message3"),
+    }
+
+    url = IFTTT_URL_TEMPLATE.format(event=IFTTT_EVENT, key=IFTTT_KEY)
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        response = await client.post(url, json=ifttt_payload)
+        response.raise_for_status()
+        logger.info("Sent IFTTT webhook for id=%s status=%s", payload.get("id"), response.status_code)
+
+
+async def check_cache_and_fire() -> None:
+    if redis_client is None:
+        logger.error("Redis client is not initialized; cannot process queue.")
+        return
+
+    now_timestamp = time.time()
+    due_reminders = await redis_client.zrangebyscore(REDIS_QUEUE_KEY, min=0, max=now_timestamp)
+
+    if not due_reminders:
+        return
+
+    logger.info("Processing %s due reminder(s) from Redis", len(due_reminders))
+
+    for reminder_json in due_reminders:
+        try:
+            data = json.loads(reminder_json)
+        except json.JSONDecodeError:
+            logger.error("Invalid JSON found in Redis queue, removing entry.")
+            await redis_client.zrem(REDIS_QUEUE_KEY, reminder_json)
+            continue
+
+        try:
+            await trigger_ifttt(data)
+            await redis_client.zrem(REDIS_QUEUE_KEY, reminder_json)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Failed to dispatch reminder id=%s: %s", data.get("id"), exc)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global redis_client, scheduler
+
+    redis_client = redis.from_url(REDIS_URL, decode_responses=True)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    scheduler = AsyncIOScheduler()
+    scheduler.add_job(check_cache_and_fire, "interval", seconds=DISPATCH_INTERVAL)
+    scheduler.start()
+    logger.info("Scheduler started; polling Redis every %s seconds", DISPATCH_INTERVAL)
+
+    yield
+
+    scheduler.shutdown()
+    await redis_client.close()
+    await engine.dispose()
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.post("/reminders", status_code=201)
+async def add_reminder(reminder: ReminderCreate):
+    if redis_client is None:
+        raise HTTPException(status_code=503, detail="Redis is not ready")
+
+    async with AsyncSessionLocal() as session:
+        new_reminder = Reminder(
+            datetime_col=reminder.when,
+            message1=reminder.message1,
+            message2=reminder.message2,
+            message3=reminder.message3,
+        )
+        session.add(new_reminder)
+        await session.commit()
+        await session.refresh(new_reminder)
+
+    reminder_data = {
+        "id": new_reminder.id,
+        "message1": reminder.message1,
+        "message2": reminder.message2,
+        "message3": reminder.message3,
+    }
+
+    score = reminder.when.timestamp()
+    await redis_client.zadd(REDIS_QUEUE_KEY, {json.dumps(reminder_data): score})
+    logger.info("Queued reminder id=%s for %s", new_reminder.id, reminder.when.isoformat())
+
+    return {"status": "scheduled", "execution_time": reminder.when, "id": new_reminder.id}
+
+
+@app.get("/health")
+async def health() -> dict:
+    return {"status": "ok"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
-requests
 fastapi
-uvicorn
+uvicorn[standard]
+httpx
+redis>=5.0.0
+apscheduler>=3.10.0
+sqlalchemy>=2.0.0
+asyncpg>=0.29.0
+aiosqlite>=0.20.0


### PR DESCRIPTION
## Summary
- add Redis ZSET-backed reminder queue with background scheduler
- persist reminders via async SQLAlchemy and queue them in Redis
- send due reminders to IFTTT using configured event/key and add health endpoint

## Details
- new POST /reminders endpoint stores reminder and enqueues JSON in Redis with timestamp score
- scheduler polls Redis every DISPATCH_INTERVAL seconds and dispatches due items; removes after send
- defaults to SQLite for dev; supports DATABASE_URL/REDIS_URL/env overrides
- logs include queue processing and send results; invalid queue entries are pruned

## Testing
- uvicorn main:app --reload
- POST /reminders with a future `when` and messages; observe log enqueue
- set IFTTT_EVENT/IFTTT_KEY; wait for dispatch window and confirm webhook fires
- GET /health returns ok

## Summary by Sourcery

Introduce a reminder scheduling service that persists reminders to a database, enqueues them in Redis, and dispatches them to IFTTT via a background scheduler.

New Features:
- Add POST /reminders endpoint to schedule reminders with messages and a scheduled time, persisting them via async SQLAlchemy.
- Add Redis ZSET-backed reminder queue with a periodic background job to dispatch due reminders to IFTTT webhooks.
- Expose a GET /health endpoint for basic service health checking.

Enhancements:
- Initialize FastAPI with an application lifespan that sets up Redis, database schema, and an APScheduler-based background worker.
- Add structured logging around queue processing, dispatch attempts, and error conditions for invalid or failed reminders.

Build:
- Extend Python dependencies to include async HTTP client, Redis, APScheduler, and async SQLAlchemy drivers needed for the reminder scheduling pipeline.

Documentation:
- Replace the README with documentation describing the reminder/IFTTT workflow, configuration via environment variables, API usage, and runtime instructions.